### PR TITLE
add upper wall check to player

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -36,6 +36,7 @@ Transform:
   m_Children:
   - {fileID: 390032358510060655}
   - {fileID: 5679715320155654171}
+  - {fileID: 4477615456786147951}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -193,7 +194,8 @@ MonoBehaviour:
   groundCheck: {fileID: 390032358510060655}
   jumpHeight: 300
   climbStrength: 0
-  wallCheck: {fileID: 0}
+  wallCheckUpper: {fileID: 4477615456786147951}
+  wallCheckLower: {fileID: 5679715320155654171}
 --- !u!1 &390032358510060654
 GameObject:
   m_ObjectHideFlags: 0
@@ -225,6 +227,37 @@ Transform:
   m_Father: {fileID: 390032358401792088}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3760106395421511750
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4477615456786147951}
+  m_Layer: 0
+  m_Name: checkWallUpper
+  m_TagString: Untagged
+  m_Icon: {fileID: -964228994112308473, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4477615456786147951
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3760106395421511750}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.23, y: 1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 390032358401792088}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7379853333878868186
 GameObject:
   m_ObjectHideFlags: 0
@@ -235,7 +268,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5679715320155654171}
   m_Layer: 0
-  m_Name: checkWallUpper
+  m_Name: checkWallLower
   m_TagString: Untagged
   m_Icon: {fileID: -964228994112308473, guid: 0000000000000000d000000000000000, type: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scripts/playerController.cs
+++ b/Assets/Scripts/playerController.cs
@@ -23,7 +23,8 @@ public class playerController : MonoBehaviour
     bool climbing = false;
     float wallCheckRadius = 0.2f;
     public float climbStrength;
-    public Transform wallCheck;
+    public Transform wallCheckUpper;
+    public Transform wallCheckLower;
     float climbStrengthAmount;
     //TODO: should add a wall layer. For now will use ground layer
 
@@ -91,19 +92,23 @@ public class playerController : MonoBehaviour
         }
 
         float vMove = Input.GetAxis("Vertical");
-        climbing = Physics2D.OverlapCircle(wallCheck.position, wallCheckRadius, groundLayer); //TODO: change groundLayer to wallLayer when you add it
+        bool headTouchingWall = Physics2D.OverlapCircle(wallCheckUpper.position, wallCheckRadius, groundLayer); //TODO: change groundLayer to wallLayer when you add it
+        bool bodyTouchingWall = Physics2D.OverlapCircle(wallCheckLower.position, wallCheckRadius, groundLayer);
+        climbing = headTouchingWall || bodyTouchingWall; 
         animator.SetBool("isClimbing", climbing);
         if(climbing)
         {
-            // float vMove = Input.GetAxis("Vertical");
             if (vMove > 0)
             {
                 animator.SetBool("isClimbing", climbing);
                 climbStrengthAmount = Mathf.Max(0, climbStrengthAmount - (Mathf.Abs(vMove) + .5f));
             }
-                
-            // else
-            //     animator.SetBool("isClimbing", false);
+
+            //give a little boost to climb onto the ground    
+            if (!headTouchingWall)
+            {
+                rigidBody.AddForce(new Vector2(0, jumpHeight));
+            }
             
             if (climbStrengthAmount > 0)
                 rigidBody.velocity = new Vector2(rigidBody.velocity.x, vMove*(maxSpeed/1.5f) );


### PR DESCRIPTION
Closes #10  - Added a upper wall check so player can start climbing if upper body is touching wall 
Closes #6 - Gives the user a boost when reaching the top of an edge. This reduces the chance of the collider getting stuck on the edge